### PR TITLE
Wrap README prose at 80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,31 +14,43 @@ enable the building of a Node.js-based application. These buildpacks include:
 - [Node Start CNB](https://github.com/paketo-buildpacks/node-start)
 
 The buildpack supports building/running simple Node applications or applications
-which utilize either [NPM](https://www.npmjs.com/) or [Yarn](https://yarnpkg.com/)
-for managing their dependencies. Support for each of these package managers is
-mutually exclusive.
+which utilize either [NPM](https://www.npmjs.com/) or
+[Yarn](https://yarnpkg.com/) for managing their dependencies. Support for each
+of these package managers is mutually exclusive.
 
-Usage examples can be found in the
-[`samples` repository under the `nodejs` directory](https://github.com/paketo-buildpacks/samples/tree/main/nodejs).
+Usage examples can be found in the [`samples` repository under the `nodejs`
+directory](https://github.com/paketo-buildpacks/samples/tree/main/nodejs).
 
 #### The Node.js buildpack is compatible with the following builder(s):
 
-- [Paketo Jammy Full Builder](https://github.com/paketo-buildpacks/builder-jammy-full)
-- [Paketo Jammy Base Builder](https://github.com/paketo-buildpacks/builder-jammy-base)
+- [Paketo Jammy Full
+  Builder](https://github.com/paketo-buildpacks/builder-jammy-full)
+- [Paketo Jammy Base
+  Builder](https://github.com/paketo-buildpacks/builder-jammy-base)
 
 This buildpack also includes the following utility buildpacks:
 
 - [Procfile CNB](https://github.com/paketo-buildpacks/procfile)
-- [Environment Variables CNB](https://github.com/paketo-buildpacks/environment-variables)
+- [Environment Variables
+  CNB](https://github.com/paketo-buildpacks/environment-variables)
 - [Image Labels CNB](https://github.com/paketo-buildpacks/image-labels)
 - [CA Certificates CNB](https://github.com/paketo-buildpacks/ca-certificates)
 - [Node Run Script CNB](https://github.com/paketo-buildpacks/node-run-script)
-- [Node Module Bill of Materials CNB](https://github.com/paketo-buildpacks/node-module-bom)
+- [Node Module Bill of Materials
+  CNB](https://github.com/paketo-buildpacks/node-module-bom)
 
-Check out the [Paketo Node.js docs](https://paketo.io/docs/buildpacks/language-family-buildpacks/nodejs/) for more information.
+Check out the [Paketo Node.js
+docs](https://paketo.io/docs/buildpacks/language-family-buildpacks/nodejs/) for
+more information.
 
 ## Maintenance
 
 ### Go Module Versioning
 
-Each buildpack is a Go module, and in the case of the Node.js buildpacks, we only maintain and support the latest versions, without providing support for any **previous** `major` or `minor` versions.  **Further the team does not currently commit to maintain the go major versions to in sync with the Semver versions used to publish releases. Keeping the go major versions up to date with the versions used to publish the buildpacks and consumed in the buildpack tomls is addhoc and based PRs being sumitted by the community**.
+Each buildpack is a Go module, and in the case of the Node.js buildpacks, we
+only maintain and support the latest versions, without providing support for any
+**previous** `major` or `minor` versions. **Further the team does not currently
+commit to maintain the go major versions to in sync with the Semver versions
+used to publish releases. Keeping the go major versions up to date with the
+versions used to publish the buildpacks and consumed in the buildpack tomls is
+addhoc and based PRs being sumitted by the community**.


### PR DESCRIPTION
Wraps prose in `README.md` at 80 columns so it stops scrolling
horizontally in editors without soft wrap.

Only paragraph text is rewrapped. Code blocks, tables, headings, URLs and
HTML are left byte for byte alone, and the rendered output is unchanged.

Opened by `gh-repo-compliancy`.
