### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,43 +14,31 @@ enable the building of a Node.js-based application. These buildpacks include:
 - [Node Start CNB](https://github.com/paketo-buildpacks/node-start)
 
 The buildpack supports building/running simple Node applications or applications
-which utilize either [NPM](https://www.npmjs.com/) or
-[Yarn](https://yarnpkg.com/) for managing their dependencies. Support for each
-of these package managers is mutually exclusive.
+which utilize either [NPM](https://www.npmjs.com/) or [Yarn](https://yarnpkg.com/)
+for managing their dependencies. Support for each of these package managers is
+mutually exclusive.
 
-Usage examples can be found in the [`samples` repository under the `nodejs`
-directory](https://github.com/paketo-buildpacks/samples/tree/main/nodejs).
+Usage examples can be found in the
+[`samples` repository under the `nodejs` directory](https://github.com/paketo-buildpacks/samples/tree/main/nodejs).
 
 #### The Node.js buildpack is compatible with the following builder(s):
 
-- [Paketo Jammy Full
-  Builder](https://github.com/paketo-buildpacks/builder-jammy-full)
-- [Paketo Jammy Base
-  Builder](https://github.com/paketo-buildpacks/builder-jammy-base)
+- [Paketo Jammy Full Builder](https://github.com/paketo-buildpacks/builder-jammy-full)
+- [Paketo Jammy Base Builder](https://github.com/paketo-buildpacks/builder-jammy-base)
 
 This buildpack also includes the following utility buildpacks:
 
 - [Procfile CNB](https://github.com/paketo-buildpacks/procfile)
-- [Environment Variables
-  CNB](https://github.com/paketo-buildpacks/environment-variables)
+- [Environment Variables CNB](https://github.com/paketo-buildpacks/environment-variables)
 - [Image Labels CNB](https://github.com/paketo-buildpacks/image-labels)
 - [CA Certificates CNB](https://github.com/paketo-buildpacks/ca-certificates)
 - [Node Run Script CNB](https://github.com/paketo-buildpacks/node-run-script)
-- [Node Module Bill of Materials
-  CNB](https://github.com/paketo-buildpacks/node-module-bom)
+- [Node Module Bill of Materials CNB](https://github.com/paketo-buildpacks/node-module-bom)
 
-Check out the [Paketo Node.js
-docs](https://paketo.io/docs/buildpacks/language-family-buildpacks/nodejs/) for
-more information.
+Check out the [Paketo Node.js docs](https://paketo.io/docs/buildpacks/language-family-buildpacks/nodejs/) for more information.
 
 ## Maintenance
 
 ### Go Module Versioning
 
-Each buildpack is a Go module, and in the case of the Node.js buildpacks, we
-only maintain and support the latest versions, without providing support for any
-**previous** `major` or `minor` versions. **Further the team does not currently
-commit to maintain the go major versions to in sync with the Semver versions
-used to publish releases. Keeping the go major versions up to date with the
-versions used to publish the buildpacks and consumed in the buildpack tomls is
-addhoc and based PRs being sumitted by the community**.
+Each buildpack is a Go module, and in the case of the Node.js buildpacks, we only maintain and support the latest versions, without providing support for any **previous** `major` or `minor` versions.  **Further the team does not currently commit to maintain the go major versions to in sync with the Semver versions used to publish releases. Keeping the go major versions up to date with the versions used to publish the buildpacks and consumed in the buildpack tomls is addhoc and based PRs being sumitted by the community**.


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
